### PR TITLE
fixed: prevent drag listeners from blocking delete button and link cl…

### DIFF
--- a/components/job-tracker/job-card.tsx
+++ b/components/job-tracker/job-card.tsx
@@ -25,6 +25,7 @@ export function JobCard({ job, onDelete, isDragging }: JobCardProps) {
 
   const handleDeleteClick = (e: React.MouseEvent) => {
     e.stopPropagation();
+    e.preventDefault();
     setIsDeleteDialogOpen(true);
   };
 
@@ -38,59 +39,61 @@ export function JobCard({ job, onDelete, isDragging }: JobCardProps) {
       <div
         ref={setNodeRef}
         style={style}
-        {...attributes}
-        {...listeners}
         className={`
-          bg-white p-4 rounded-md shadow-sm border 
-          hover:shadow-md transition-shadow duration-200
-          cursor-grab active:cursor-grabbing
-          ${isDragging ? 'opacity-75' : ''}
-          ${isCurrentlyDragging ? 'opacity-0' : ''}
-        `}
+      bg-white p-4 rounded-md shadow-sm border 
+      hover:shadow-md transition-shadow duration-200
+      ${isDragging ? 'opacity-75' : ''}
+      ${isCurrentlyDragging ? 'opacity-0' : ''}
+    `}
       >
-        <div className="flex justify-between items-start gap-2">
-          <div className="flex-1 min-w-0">
-            <h3 className="font-medium text-gray-900 truncate">{job.title}</h3>
-            <div className="flex items-center gap-1 text-sm text-gray-600 mt-1">
-              <Building2 className="h-3 w-3" />
-              <span className="truncate">{job.company}</span>
+        <div className='flex justify-between items-start gap-2 mb-2'>
+          <div
+            {...attributes}
+            {...listeners}
+            className='flex-1 min-w-0 cursor-grab active:cursor-grabbing'
+          >
+            <h3 className='font-medium text-gray-900 truncate'>{job.title}</h3>
+            <div className='flex items-center gap-1 text-sm text-gray-600 mt-1'>
+              <Building2 className='h-3 w-3' />
+              <span className='truncate'>{job.company}</span>
             </div>
-            <div className="flex items-center gap-1 text-xs text-gray-500 mt-1">
-              <Calendar className="h-3 w-3" />
+            <div className='flex items-center gap-1 text-xs text-gray-500 mt-1'>
+              <Calendar className='h-3 w-3' />
               <span>{formatDate(job.createdAt)}</span>
             </div>
           </div>
+
           <Button
-            variant="ghost"
-            size="icon"
-            className="text-gray-400 hover:text-red-600 transition-colors -mr-2 -mt-2"
+            variant='ghost'
+            size='icon'
+            className='text-gray-400 hover:text-red-600 transition-colors shrink-0'
             onClick={handleDeleteClick}
           >
-            <Trash2 className="h-4 w-4" />
+            <Trash2 className='h-4 w-4' />
           </Button>
         </div>
+
         {job.link && (
           <a
             href={job.link}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm text-blue-500 hover:text-blue-700 mt-2 flex items-center gap-1 group"
-            onClick={e => e.stopPropagation()}
+            target='_blank'
+            rel='noopener noreferrer'
+            className='text-sm text-blue-500 hover:text-blue-700 flex items-center gap-1 group w-fit'
+            onClick={(e) => e.stopPropagation()}
           >
-            View Job 
-            <ExternalLink className="h-3 w-3 transition-transform group-hover:translate-x-0.5" />
+            View Job
+            <ExternalLink className='h-3 w-3 transition-transform group-hover:translate-x-0.5' />
           </a>
         )}
       </div>
-
       <ConfirmationDialog
         open={isDeleteDialogOpen}
         onOpenChange={setIsDeleteDialogOpen}
         onConfirm={handleConfirmDelete}
-        title="Delete Job"
+        title='Delete Job'
         description={`Are you sure you want to delete "${job.title}" at ${job.company}?`}
-        confirmText="Delete"
-        cancelText="Cancel"
+        confirmText='Delete'
+        cancelText='Cancel'
       />
     </>
   );


### PR DESCRIPTION

<img width="1677" height="940" alt="Screenshot 2025-11-28 at 1 30 20 PM" src="https://github.com/user-attachments/assets/f806a80c-f062-4a19-b13e-759f9b10ad56" />
### Problem
The delete button and "View Job" link were not clickable because the drag-and-drop listeners were applied to the entire card, capturing all pointer events and preventing clicks from reaching the interactive elements.

### Solution
Restructured the drag listeners to only apply to the job content area (title, company, date), while keeping the delete button and link outside the draggable zone. This allows:
- Dragging the card by clicking/holding on the job information
- Clicking the delete button to remove jobs
- Clicking the link to open job postings in a new tab

### Changes
- Moved `{...attributes}` and `{...listeners}` from the root card element to a wrapper around only the job content
- Positioned delete button alongside the content in a flex container
- Kept the "View Job" link outside the draggable area
- Fixed layout spacing and alignment issues

### Testing
- ✅ Card can be dragged by clicking on job title/company/date
- ✅ Delete button opens confirmation dialog
- ✅ "View Job" link opens in new tab
- ✅ Visual layout remains consistent